### PR TITLE
Fixd UUID code to generate 26 letter IDs as standard

### DIFF
--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -12,7 +12,16 @@ var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769").WithPaddin
 // characters long.  It is a UUID version 4 Guid that is zbased32 encoded
 // without the padding.
 func NewID() string {
-	return encoding.EncodeToString([]byte(uuid.NewString()))
+	return encoding.EncodeToString(newRandom()[:])
+}
+
+func newRandom() *uuid.UUID {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return nil
+	}
+
+	return &id
 }
 
 func CoalesceInt(values ...int) int {

--- a/server/utils/utils_test.go
+++ b/server/utils/utils_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewID(t *testing.T) {
+	t.Run("generated ID should always be 26 characters long", func(t *testing.T) {
+		require.Equal(t, 26, len(NewID()))
+	})
+}


### PR DESCRIPTION
#### Summary
#19 caused a bug as it generated UUIDs that were longer than 26 letters. Since DB columns were designed for 26 letter IDs, it broke the store layer. This PR includes some changes to use Google UUID library to generate 26 letter UUIDs.

