### PR TITLE
Added prefix before generic modal classes

### DIFF
--- a/webapp/src/components/common/modal/modal.tsx
+++ b/webapp/src/components/common/modal/modal.tsx
@@ -146,7 +146,7 @@ function GenericModal({
             <button
                 autoFocus={autoFocusConfirmButton}
                 type='submit'
-                className={classNames('GenericModal__button btn btn-primary', isConfirmOrDeleteClassName, confirmButtonClassName, {
+                className={classNames('common_GenericModal__button btn btn-primary', isConfirmOrDeleteClassName, confirmButtonClassName, {
                     disabled: isConfirmDisabled,
                 })}
                 onClick={handleConfirmClick}
@@ -178,7 +178,7 @@ function GenericModal({
         return (
             <button
                 type='button'
-                className={classNames('GenericModal__button btn btn-tertiary', cancelButtonClassName)}
+                className={classNames('common_GenericModal__button btn btn-tertiary', cancelButtonClassName)}
                 onClick={handleCancelClick}
             >
                 {buttonText}
@@ -192,9 +192,9 @@ function GenericModal({
         }
 
         return (
-            <div className='GenericModal__header'>
+            <div className='common_GenericModal__header'>
                 <h1
-                    id='genericModalLabel'
+                    id='common_genericModalLabel'
                     className='modal-title'
                 >
                     {modalHeaderText}
@@ -210,7 +210,7 @@ function GenericModal({
             role='dialog'
             aria-label={ariaLabel}
             aria-labelledby={ariaLabel ? undefined : 'genericModalLabel'}
-            dialogClassName={classNames('a11y__modal GenericModal', 'GenericModal__compassDesign', className)}
+            dialogClassName={classNames('common_GenericModal', 'common_GenericModal__compassDesign', className)}
             show={showModal}
             restoreFocus={true}
             enforceFocus={enforceFocus}
@@ -224,7 +224,7 @@ function GenericModal({
             <div
                 onKeyDown={onEnterKeyDown}
                 tabIndex={tabIndex || 0}
-                className='GenericModal__wrapper-enter-key-press-catcher'
+                className='common_GenericModal__wrapper-enter-key-press-catcher'
             >
                 <Modal.Header closeButton={true}>
                     <div>
@@ -235,13 +235,13 @@ function GenericModal({
                 <Modal.Body className={classNames({divider: bodyDivider})}>
                     {
                         errorText && (
-                            <div className='genericModalError'>
+                            <div className='common_genericModalError'>
                                 <Icon icon='alert-outline'/>
                                 <span>{errorText}</span>
                             </div>
                         )
                     }
-                    <div className={classNames('GenericModal__body', {padding: bodyPadding})}>{children}</div>
+                    <div className={classNames('common_GenericModal__body', {padding: bodyPadding})}>{children}</div>
                 </Modal.Body>
                 {(cancelButton || confirmButton || footerContent) && (
                     <Modal.Footer className={classNames({divider: footerDivider})}>

--- a/webapp/src/components/common/modal/style.scss
+++ b/webapp/src/components/common/modal/style.scss
@@ -1,5 +1,5 @@
-.console__body .modal .GenericModal,
-.app__body .modal .GenericModal {
+.console__body .modal .common_GenericModal,
+.app__body .modal .common_GenericModal {
     &.modal-dialog {
         margin-top: calc(50vh - 240px);
     }
@@ -72,7 +72,7 @@
         padding: 24px 32px;
     }
 
-    &.GenericModal__compassDesign {
+    &.common_GenericModal__compassDesign {
         .modal-content {
             .modal-body {
                 .GenericModal__body {
@@ -84,7 +84,7 @@
                 }
             }
 
-            .genericModalError {
+            .common_genericModalError {
                 display: flex;
                 box-sizing: border-box;
                 flex: 1;


### PR DESCRIPTION
#### Summary
Added `common_` prefix before generic modal classes, `common_` indicating the common components component, where it will be moved to later on.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-58747

