### PR TITLE
Removed redundant mutex from migration and used MM migration timeout setting for plugin migration timeout

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -110,13 +110,14 @@ func (p *Plugin) createStoreParams() (*store.Params, error) {
 	}
 
 	return &store.Params{
-		DBType:           *mmConfig.SqlSettings.DriverName,
-		ConnectionString: *mmConfig.SqlSettings.DataSource,
-		TablePrefix:      store.TablePrefix,
-		SkipMigrations:   false,
-		PluginAPI:        p.API,
-		DB:               db,
-		Driver:           p.Driver,
+		DBType:                  *mmConfig.SqlSettings.DriverName,
+		ConnectionString:        *mmConfig.SqlSettings.DataSource,
+		TablePrefix:             store.TablePrefix,
+		SkipMigrations:          false,
+		PluginAPI:               p.API,
+		DB:                      db,
+		Driver:                  p.Driver,
+		MigrationTimeoutSeconds: *mmConfig.SqlSettings.MigrationsStatementTimeoutSeconds,
 	}, nil
 }
 

--- a/server/store/migrate_test.go
+++ b/server/store/migrate_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testMigrationTimeoutSeconds = 10
+
 func TestMigrations(t *testing.T) {
 	tests := []StoreTests{
 		testMigration,
@@ -32,7 +34,7 @@ func testMigration(t *testing.T, namePrefix string, sqlStore *SQLStore, tearDown
 		require.NoError(t, err)
 
 		// now ru-run the migrations
-		err = sqlStore.Migrate()
+		err = sqlStore.Migrate(testMigrationTimeoutSeconds)
 		require.NoError(t, err)
 
 		// now lets check the row count again.

--- a/server/store/mocks/Store.go
+++ b/server/store/mocks/Store.go
@@ -312,17 +312,17 @@ func (_m *Store) IncrementSurveyResponseCount(surveyID string) error {
 	return r0
 }
 
-// Migrate provides a mock function with given fields:
-func (_m *Store) Migrate() error {
-	ret := _m.Called()
+// Migrate provides a mock function with given fields: migrationTimeoutSeconds
+func (_m *Store) Migrate(migrationTimeoutSeconds int) error {
+	ret := _m.Called(migrationTimeoutSeconds)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Migrate")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(int) error); ok {
+		r0 = rf(migrationTimeoutSeconds)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/store/params.go
+++ b/server/store/params.go
@@ -8,13 +8,14 @@ import (
 )
 
 type Params struct {
-	DBType           string
-	ConnectionString string
-	TablePrefix      string
-	DB               *sql.DB
-	PluginAPI        plugin.API
-	SkipMigrations   bool
-	Driver           plugin.Driver
+	DBType                  string
+	ConnectionString        string
+	TablePrefix             string
+	DB                      *sql.DB
+	PluginAPI               plugin.API
+	SkipMigrations          bool
+	Driver                  plugin.Driver
+	MigrationTimeoutSeconds int
 }
 
 func (p Params) IsValid() error {

--- a/server/store/sqlstore.go
+++ b/server/store/sqlstore.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/plugin"
-	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
 	"github.com/mattermost/squirrel"
 
 	"github.com/mattermost/mattermost-plugin-user-survey/server/model"
@@ -61,7 +60,7 @@ func New(params Params) (*SQLStore, error) {
 	}
 
 	if !store.skipMigrations {
-		if migrationErr := store.Migrate(); migrationErr != nil {
+		if migrationErr := store.Migrate(params.MigrationTimeoutSeconds); migrationErr != nil {
 			params.PluginAPI.LogError(`Table creation / migration failed`, "error", migrationErr.Error())
 			return nil, migrationErr
 		}
@@ -82,10 +81,6 @@ func (s *SQLStore) checkBinaryParams() (bool, error) {
 	}
 
 	return parsedURL.Query().Get("binary_parameters") == "yes", nil
-}
-
-func (s *SQLStore) newMutex(name string) (*cluster.Mutex, error) {
-	return cluster.NewMutex(s.pluginAPI, name)
 }
 
 func (s *SQLStore) Shutdown() error {

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -9,7 +9,7 @@ import (
 
 type Store interface {
 	Shutdown() error
-	Migrate() error
+	Migrate(migrationTimeoutSeconds int) error
 	GetTemplateHelperFuncs() template.FuncMap
 	GetSchemaName() (string, error)
 	GetSurveysByStatus(status string) ([]*model.Survey, error)


### PR DESCRIPTION
#### Summary
Applied following changes to migration code-
1. Removed manually managed mutex as morph already manages itself via the `morph.WithLock()` function which we're already using.
2. Removed the hardcoded migration timeout config and used Mattermost's timeout config.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-59845

