### PR TITLE
Made survey duration a number in report survey metadata

### DIFF
--- a/server/model/survey_stat.go
+++ b/server/model/survey_stat.go
@@ -4,8 +4,6 @@
 package model
 
 import (
-	"strconv"
-
 	"github.com/mattermost/mattermost-plugin-user-survey/server/utils"
 )
 
@@ -23,7 +21,7 @@ func (stat *SurveyStat) ToMetadata() map[string]interface{} {
 	return map[string]interface{}{
 		"id":              stat.ID,
 		"start_time":      utils.FormatUnixTimeMillis(stat.StartTime),
-		"duration":        strconv.Itoa(stat.Duration),
+		"duration":        stat.Duration,
 		"questions":       stat.SurveyQuestions.GetMetadata(),
 		"receipt_count":   stat.ReceiptCount,
 		"response_count":  stat.ResponseCount,


### PR DESCRIPTION
#### Summary
Made survey duration a number in report survey metadata instead of a string.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-60206

